### PR TITLE
Fix broken gist loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ function open() {
         var contents = c.appendChild(ce('div', 'gist-map-contents'));
         contents.innerHTML = Object.keys(gist.files).join(', ');
         c.onclick = function(elem) {
-            onclick(gist, elem);
+            page('/gists/' + gist.id, function(err, res){
+                onclick(res, elem);
+            });
         };
     }
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/geojson.io/issues/385

Requests for [a list of gists](https://developer.github.com/v3/gists/#list-gists) (e.g. paginated gists) do not contain a 'content' field, a second request needs to get the [selected gist](https://developer.github.com/v3/gists/#get-a-single-gist) on click to get the content of the gist.
